### PR TITLE
Added event parameter to ripple mousedown.

### DIFF
--- a/thescript.js
+++ b/thescript.js
@@ -9,7 +9,7 @@ var uname;
 $( document ).ready(function() {
    // alert("One or more required field has been left blank.");
 
-$(".ripple").mousedown( function() {
+$(".ripple").mousedown( function(event) {
 
 
 	$(this).append('<div class="rippleEffect"/>');


### PR DESCRIPTION
I'm not really sure why the event parameter is not needed in Chrome, but this seems to fix the issue for Firefox. 
